### PR TITLE
Add ability to parse dynamic ranges

### DIFF
--- a/spcconverter.qml
+++ b/spcconverter.qml
@@ -603,7 +603,10 @@ MuseScore {
                 var volume = getVolumeFromDynamic(dynamicType) || null;
                 if (volume != null) {
                     prefix += "v" + volume;
+                } else {
+                    debugLog("Warning: No support for dynamic range provided: " + dynamicType);
                 }
+                continue;
             }
             //Make sure it's on the current staff
             if (annotations[i].staff.is(staff)) {

--- a/spcconverter.qml
+++ b/spcconverter.qml
@@ -593,9 +593,9 @@ MuseScore {
         var postfix = "";
         for (var i = 0; i < annotations.length; i++) {
             if (annotations[i].type == Element.DYNAMIC) {
-                var dynamicType = annotations[i].subtypeName();
-                var volume = getVolumeFromDynamic(dynamicType) || null;
-                if (volume != null) {
+                const dynamicType = annotations[i].subtypeName();
+                const volume = getVolumeFromDynamic(dynamicType);
+                if (volume) {
                     prefix += volume;
                 } else {
                     debugLog("Warning: No support for dynamic range provided: " + dynamicType);

--- a/spcconverter.qml
+++ b/spcconverter.qml
@@ -573,20 +573,14 @@ MuseScore {
 
     function getVolumeFromDynamic(dynamic) {
         var volumeMap = {
-            // 255
+            // See https://docs.google.com/spreadsheets/d/1bKVuwYYAAe_jJ9UXeXnbFPn9u9fpuFrp3WUhjI0jUmM/edit#gid=109806222
             "fff": "q7F",
-            // 222
             "ff": "q7D",
-            // 186
             "f": "q7B",
-            // 150
             "mf": "q79",
             "mp": "q77",
-            // 108
             "p": "q75",
-            // 72
             "pp": "q73",
-            // 36
             "ppp": "q71"
         };
         return volumeMap[dynamic];

--- a/spcconverter.qml
+++ b/spcconverter.qml
@@ -571,27 +571,55 @@ MuseScore {
         debugLog("Loaded parameter settings from score.");
     }
 
-    function processAnnotations(texts, staff) {
+    function getVolumeFromDynamic(dynamic) {
+        var volumeMap = {
+            // 255
+            "fff": "FF",
+            // 222
+            "ff": "DE",
+            // 186
+            "f": "BA",
+            // 150
+            "mf": "96",
+            "mp": "96",
+            // 108
+            "p": "6C",
+            // 72
+            "pp": "48",
+            // 36
+            "ppp": "24"
+        };
+        return volumeMap[dynamic];
+    }
+
+    function processAnnotations(annotations, staff) {
         var addSection = false;
         var sectionName = "";
         var prefix = "";
         var postfix = "";
-        for (var i = 0; i < texts.length; i++) {
+        for (var i = 0; i < annotations.length; i++) {
+            if (annotations[i].type == Element.DYNAMIC) {
+                var dynamicType = annotations[i].subtypeName();
+                var volume = getVolumeFromDynamic(dynamicType) || null;
+                if (volume != null) {
+                    prefix += "v" + volume;
+                }
+            }
             //Make sure it's on the current staff
-            if (texts[i].staff.is(staff)) {
-                if(texts[i].text[0] == "@") {
-                    prefix += texts[i].text.trim();
+            if (annotations[i].staff.is(staff)) {
+                if(annotations[i].text[0] == "@") {
+                    prefix += annotations[i].text.trim();
                 }
-                if (texts[i].text[0] == "-") {
-                    prefix += processCommand(texts[i].text.trim());
+                if (annotations[i].text[0] == "-") {
+                    prefix += processCommand(annotations[i].text.trim());
                 }
-                if (texts[i].text[0] == "+") {
-                    postfix += processCommand(texts[i].text.trim());
+                if (annotations[i].text[0] == "+") {
+                    postfix += processCommand(annotations[i].text.trim());
                 }
-                if(texts[i].text.indexOf("#SECTION") > -1) {
-                    if(texts[i].text.substring(0, 8) === "#SECTION") {
+                if(annotations[i].text.indexOf("#SECTION") > -1) {
+                    if(annotations[i].text.substring(0, 8) === "#SECTION") {
                         addSection = true;
-                        sectionName = texts[i].text.substring(9, texts[i].length);  
+                        sectionName = annotations[i].text.substring(9, annotations[i].length);  
                     }
                 }
             }

--- a/spcconverter.qml
+++ b/spcconverter.qml
@@ -574,20 +574,20 @@ MuseScore {
     function getVolumeFromDynamic(dynamic) {
         var volumeMap = {
             // 255
-            "fff": "FF",
+            "fff": "q7F",
             // 222
-            "ff": "DE",
+            "ff": "q7D",
             // 186
-            "f": "BA",
+            "f": "q7B",
             // 150
-            "mf": "96",
-            "mp": "96",
+            "mf": "q79",
+            "mp": "q77",
             // 108
-            "p": "6C",
+            "p": "q75",
             // 72
-            "pp": "48",
+            "pp": "q73",
             // 36
-            "ppp": "24"
+            "ppp": "q71"
         };
         return volumeMap[dynamic];
     }
@@ -602,7 +602,7 @@ MuseScore {
                 var dynamicType = annotations[i].subtypeName();
                 var volume = getVolumeFromDynamic(dynamicType) || null;
                 if (volume != null) {
-                    prefix += "v" + volume;
+                    prefix += volume;
                 } else {
                     debugLog("Warning: No support for dynamic range provided: " + dynamicType);
                 }


### PR DESCRIPTION
- Extend `processAnnotations` to deduce dynamic ranges and add `v` modifier to output.
- Add warning if dynamic annotation is not supported

Note to reviewer: I am very new to porting, so I haven't had a chance to test this. Let me know if any changes are needed.