### PR TITLE
Add OS detection logic

### DIFF
--- a/spcconverter.qml
+++ b/spcconverter.qml
@@ -100,8 +100,6 @@ MuseScore {
             }
         }
         
-        CheckBox { Layout.leftMargin: 10; id: unixPathsBox; text: "Use UNIX filepaths" }
-
         RowLayout {
             Layout.leftMargin: 10
             Layout.topMargin:10
@@ -186,7 +184,10 @@ MuseScore {
         folder: shortcuts.home
         onAccepted: {
             var path = fileDialog.fileUrl.toString();
-            if (unixPathsBox.checked) {
+            var os = Qt.platform.os;
+            var unixPath = (os === "linux") || (os === "osx");
+
+            if (unixPath) {
                  filePathLabel.text = path.substring(7, path.length);
                  exportFile.source = path.substring(7, path.length);
             } else {


### PR DESCRIPTION
QML exposes a global Qt object which can exposes platform information, including the OS.  That can be used instead of requiring the user to select it.